### PR TITLE
Allow overriding java executable used by clojure script (fixes TDEPS-125)

### DIFF
--- a/src/main/resources/clojure
+++ b/src/main/resources/clojure
@@ -139,7 +139,8 @@ done
 
 # Find java executable
 set +e
-JAVA_CMD=$(type -p java)
+JAVA_CMD=${JAVA_CMD:-$(type -p java)}
+
 set -e
 if [[ ! -n "$JAVA_CMD" ]]; then
   if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]]; then


### PR DESCRIPTION
## What is the current behavior?

There is currently no way of overriding the Java executable used by clj/clojure on a per-invocation basis. See [TDEPS-125](https://clojure.atlassian.net/browse/TDEPS-125) for details.

## What is the new behavior?

The variable `JAVA_CMD` defaults to the setting from the `clojure` script's environment if set and not empty, otherwise the current lookup mechanism is used.