### PR TITLE
Improve `curl` options in install scripts

### DIFF
--- a/src/main/resources/clojure/install/linux-install.sh
+++ b/src/main/resources/clojure/install/linux-install.sh
@@ -26,7 +26,18 @@ if [[ "$prefix_param" = "-p" || "$prefix_param" = "--prefix" ]]; then
 fi
 
 echo "Downloading and expanding tar"
-curl -L -O https://github.com/clojure/brew-install/releases/download/${project.version}/clojure-tools-${project.version}.tar.gz
+curl \
+  --connect-timeout 3 \
+  --fail \
+  --max-time 60
+  --no-progress-meter \
+  --retry-max-time 60 \
+  --retry 5
+  --retry-connrefused \
+  --remote-name \
+  --location \
+  https://github.com/clojure/brew-install/releases/download/${project.version}/clojure-tools-${project.version}.tar.gz
+
 tar xzf clojure-tools-${project.version}.tar.gz
 
 lib_dir="$prefix_dir/lib"

--- a/src/main/resources/clojure/install/posix-install.sh
+++ b/src/main/resources/clojure/install/posix-install.sh
@@ -26,7 +26,18 @@ if [ "$prefix_param" = "-p" -o "$prefix_param" = "--prefix" ]; then
 fi
 
 echo "Downloading and expanding tar"
-curl -L -O https://github.com/clojure/brew-install/releases/download/${project.version}/clojure-tools-${project.version}.tar.gz
+curl \
+  --connect-timeout 3 \
+  --fail \
+  --max-time 60
+  --no-progress-meter \
+  --retry-max-time 60 \
+  --retry 5
+  --retry-connrefused \
+  --remote-name \
+  --location \
+  https://github.com/clojure/brew-install/releases/download/${project.version}/clojure-tools-${project.version}.tar.gz
+
 tar xzf clojure-tools-${project.version}.tar.gz
 
 lib_dir="$prefix_dir/lib"


### PR DESCRIPTION
This PR improves the `curl` options used in the Linux and POSIX install scripts.

Our Heroku buildpack for Clojure uses these install scripts to install the CLI. We noticed intermittent install failures related to the download of the Clojure tools. I believe most of them could be avoided with a slightly changed curl command line options.

The options used in this PR are based on our Heroku best-practices for curl commands. They are obviously opinionated, so I am happy to adjust as needed. I left some details for each of them below, including curl version compatibility for the more recent `curl` additions.

I also switched the short-form options `-O` and `-L` to their long from equivalents as they are easier to grasp without needing to refer to the man page and for consistency with the newly added options.

| Option                                                                         | Introduced               | Rationale                                                                                                     |
|--------------------------------------------------------------------------------|--------------------------|---------------------------------------------------------------------------------------------------------------|
| [`--connect-timeout 3`](https://curl.se/docs/manpage.html#--connect-timeout)   | -                        | Prevents hanging when server is unreachable.                                                                  |
| [`--fail`](https://curl.se/docs/manpage.html#-f)                               | -                        | Exit with error code `22` for HTTP responses with status codes >= `400`.                                      |
| [`--max-time 60`](https://curl.se/docs/manpage.html#-m)                        | -                        | Prevents hanging indefinitely with slow/stalling connections.                                                 |
| [`--no-progress-meter`](https://curl.se/docs/manpage.html#--no-progress-meter) | curl `7.67.0` (Nov 2019) | Cleaner output. But less drastic than `--silent` and will still output diagnostic information (i.e. retries). |
| [`--retry-max-time 60`](https://curl.se/docs/manpage.html#--retry-max-time)    | -                        | Prevents hanging indefinitely with slow/stalling connections.                                                 |
| [`--retry 5`](https://curl.se/docs/manpage.html#--retry)                       | curl `7.12.3` (Dec 2004) | Retry up to 5 times on transient errors.                                                                      |
| [`--retry-connrefused`](https://curl.se/docs/manpage.html#--retry-connrefused) | curl `7.52.0` (Dec 2016) | Consider connection refused as a transient error for `--retry`.                                               |
